### PR TITLE
[1주차] [알고리즘] 두 큐 합 같게 만들기 & 기능 개발

### DIFF
--- a/1week/문진수/[프로그래머스] 기능개발.java
+++ b/1week/문진수/[프로그래머스] 기능개발.java
@@ -1,0 +1,15 @@
+import java.util.*;
+
+class Solution {
+    public int[] solution(int[] progresses, int[] speeds) {
+        int[] dayOfend = new int[100];
+        int day = -1;
+        for(int i=0; i<progresses.length; i++) {
+            while(progresses[i] + (day*speeds[i]) < 100) {
+                day++;
+            }
+            dayOfend[day]++;
+        }
+        return Arrays.stream(dayOfend).filter(i -> i!=0).toArray();
+    }
+}

--- a/1week/문진수/[프로그래머스] 두_큐의합_같게하기.java
+++ b/1week/문진수/[프로그래머스] 두_큐의합_같게하기.java
@@ -1,0 +1,40 @@
+import java.util.*;
+class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+        Queue<Integer> q1 = new LinkedList<>();
+        Queue<Integer> q2 = new LinkedList<>();
+
+        long total = 0;
+        long hap = 0;
+        int ans = 0;
+        for (int i = 0; i < queue1.length ; i++) {
+
+            total+= queue1[i];
+            hap += queue1[i];
+            total+= queue2[i];
+            q1.add(queue1[i]);
+            q2.add(queue2[i]);
+        }
+
+
+        total /= 2;
+
+        while(hap != total){
+            if(ans > (queue1.length + queue2.length)*2) return -1;
+            if(hap == total){break;}
+            else if(hap > total){
+                int temp1 = q1.poll();
+                hap-=temp1;
+                q2.add(temp1);
+            }else{
+                int temp2 = q2.poll();
+                hap+= temp2;
+                q1.add(temp2);
+            }
+            ans++;
+        }
+
+        return ans;
+
+    }
+}


### PR DESCRIPTION
## 두 큐 합 같게 만들기
   
  - 풀이 의도
    문제제목에서 큐 두개를 써서 뭔가 풀어야겠다는 생각이 들었습니다. 
    total/2 가 되는 hap 값을 찾습니다. 
    탈출이 아닌 큐에 있던 값이 옮겨졌을때 cnt++


  - 개선점
    dfs로 뭔가 풀어볼수 있을까 했지만 실패했습니다. 
   변수를 줄여서 좀 더 가독성 좋게 짤수 있지 않을까? 하고 생각했습니다. 
   ans > (queue1.length + queue2.length) * 2 =>두 큐의 길이의 2배를 넘어서면 -1 반환 
   하는데 왜 그런지 명확하게 모르겠습니다. 

## 기능 개발

  - 풀이 의도
     그리디 느낌으로 풀어야 된다고 생각했습니다. 
     progresses 배열 값 만큼 return 값이 들어가 있어야한다고 생각했습니다. 
     하루씩 쌓여 갈때마다 진도율이 100이 넘었는지 조건을 통해 확인하고 넘었다면 당일 1건의 배포가 이루어집니다. 

   - 개선점
       Arrays.stream(dayOfend).filter(i -> i!=0).toArray();
       ArrayList로 0 이 아닌 값을 받아서  배열로 return 하고자 했는데
        wrapper class -> 기본형 배열으로 바꿔주어야했고 
       이를  쉽게 변환시켜주는 stream을 사용해보았습니다. 
       
  